### PR TITLE
Accordion TRIGGER BUTTON must have type="button"

### DIFF
--- a/lib/rbui/accordion/accordion_trigger.rb
+++ b/lib/rbui/accordion/accordion_trigger.rb
@@ -8,6 +8,7 @@ module RBUI
 
     def default_attrs
       {
+        type: "button",
         data: {action: "click->rbui--accordion#toggle"},
         class: "w-full flex flex-1 items-center justify-between py-4 text-sm font-medium transition-all hover:underline"
       }


### PR DESCRIPTION
The accordion trigger uses a button to open and close its content. The issue was that this button did not have its type set to `button`, causing it to submit forms by mistake. Upon inspecting the Shadcn Accordion, we can see it uses `type="button"`

<img width="954" alt="Screenshot 2024-10-23 at 11 20 29" src="https://github.com/user-attachments/assets/9fd56168-417f-45d6-9659-aca1ecfca8cf">
